### PR TITLE
Update 研究室サーバの使い方.md

### DIFF
--- a/研究室サーバの使い方.md
+++ b/研究室サーバの使い方.md
@@ -137,17 +137,45 @@ $ ssh n1
 パッケージはインストールが難しいので、気軽に試行錯誤できる環境があると便利。
 
 その場合はcondaの仮想環境を使って、ユーザレベルでパッケージをインストールして使うとよい。
+
+condaの仮想環境を初めて作成する場合は、`~/.bashrc`に以下のスクリプトを追記しておく。
+```bash
+# >>> conda initialize >>>
+# !! Contents within this block are managed by 'conda init' !!
+__conda_setup="$('/opt/anaconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "/opt/anaconda3/etc/profile.d/conda.sh" ]; then
+        . "/opt/anaconda3/etc/profile.d/conda.sh"
+    else
+        export PATH="/opt/anaconda3/bin:$PATH"
+    fi
+fi
+unset __conda_setup
+# <<< conda initialize <<<
+```
+
 仮想環境を作成するにはターミナルから以下のようにする(ここでは仮想環境の名前を `myenv` とする。
 ちなみにデフォルトの環境は `base` という名前が付いている)。
-デフォルトの `base` 環境に既にインストールされているパッケージはそのまま引き継がれる。
+デフォルトの `base` 環境にインストールされているパッケージは、そのままでは引き継がれないので注意。
 
 ```bash
 (base) $ conda create -n myenv
 # その後 proceed してよいか聞かれたら y と答える
 ```
 
+デフォルトの`base`環境にインストール済みのパッケージを引き継ぎたい場合は、以下のようにする。
+
+```bash
+(base) $ conda create -n myenv --clone base
+# もしくは以下でroot環境を引き継げる
+(base) $ conda create -n myenv anaconda
+```
+
 もしくはデフォルトとは異なるpythonのバージョンを指定して仮想環境を作成するには以下のようにする。
-pythonが変更される場合は、デフォルトの `base` 環境のパッケージは引き継がれない。
+pythonが変更される場合、デフォルトの `base` 環境のパッケージは引き継げない。
+(引き継ぎたい場合は、パッケージ構成を予めテキストファイルなどに書き出しておく必要がある)
 
 ```bash
 (base) $ conda create -n myenv python=3.9


### PR DESCRIPTION
1. `~/.bashrc`にconda initializeのスクリプトを書く説明を追加しました。
2. デフォルトではbase環境のパッケージは引き継がれないので、引き継ぐための方法を追加しました。